### PR TITLE
Fix item duplication bug

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7,13 +7,17 @@ function swap(e, p, new_name)
     -- save some properties
     local old_health = e.health
     local old_backer_name = e.backer_name
+    local entity_force = e.force
+    local entity_position = e.position
+    local entity_quality = e.quality
 
-    e = e.surface.create_entity{
+    -- destroy current and replace with new variant
+    e.destroy()
+    e = p.surface.create_entity{
         name = new_name,
-        position = e.position,
-        quality = e.quality,
-        force = e.force,
-        fast_replace = true,
+        position = entity_position,
+        quality = entity_quality,
+        force = entity_force,
         player = p,
     }
 


### PR DESCRIPTION
Currently, when swapping between normal and passive radar, an additional radar (with matching quality) is added to the player's inventory, effectively giving the player a free copy every time the swap happens (bug stems from fast_replace = true.

This PR fixes the bug by first destroying the item and then immediately creating a new one in it's old position. The outcome from the player's perspective is unchanged.